### PR TITLE
Release 0.0.13 - download hearers & upload fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Fusion SDK is published to Maven Central and can be retrieved from there usi
   <dependency>
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
   </dependency>
 ```
 
@@ -109,7 +109,6 @@ Fusion fusion = Fusion.builder().configuration(FusionConfiguration.builder()
 * _downloadPath_ - Configures the path where distributions should be downloaded to. Defaults to "downloads"
 * _singlePartUploadSizeLimit_ - Max size in MB of data allowed for a single part upload.  if 32MB was the max size then 32 would be provided. Defaults to 50.
 * _uploadPartSize_ - Upload part chunk size. If a value such as 8MB is required, then client would set this value to 8.  Defaults to 16MB.
-* _maxInFluxDataSize_ - Max in flux data to be read at a given time.  Use this to protect data read to heap during upload.  If a value such as 100MB is required, set to 100. Defaults to 500MB.
 * _uploadThreadPoolSize_ - Size of Thread-Pool to be used for uploading chunks of a multipart file. Defaults to number of available processors.
 * _downloadThreadPoolSize_ - Size of Thread-Pool to be used for uploading chunks of a multipart file. Defaults to number of available processors.
 * _digestAlgorithm_ - Digest algorithm used by fusion to verify the integrity of upload/downloads. Defaults to SHA-256.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Fusion SDK is published to Maven Central and can be retrieved from there usi
   <dependency>
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
-    <version>0.0.11-SNAPSHOT</version>
+    <version>0.0.12-SNAPSHOT</version>
   </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Fusion SDK is published to Maven Central and can be retrieved from there usi
   <dependency>
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>0.0.12</version>
   </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.12</version>
+    <version>0.0.13</version>
 
     <name>fusion-sdk</name>
     <description>A Java SDK for the Fusion platform API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -393,14 +393,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.5.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <!-- this can be changed to true once we are comfortable with the release process being correct -->
-                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <tokenAuth>true</tokenAuth>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.10</version>
+    <version>0.0.11-SNAPSHOT</version>
 
     <name>fusion-sdk</name>
     <description>A Java SDK for the Fusion platform API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.11-SNAPSHOT</version>
+    <version>0.0.12-SNAPSHOT</version>
 
     <name>fusion-sdk</name>
     <description>A Java SDK for the Fusion platform API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>io.github.jpmorganchase.fusion</groupId>
     <artifactId>fusion-sdk</artifactId>
     <packaging>jar</packaging>
-    <version>0.0.12-SNAPSHOT</version>
+    <version>0.0.12</version>
 
     <name>fusion-sdk</name>
     <description>A Java SDK for the Fusion platform API</description>

--- a/src/main/java/io/github/jpmorganchase/fusion/Fusion.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/Fusion.java
@@ -395,6 +395,29 @@ public class Fusion {
      * @throws OAuthException if a token could not be retrieved for authentication
      */
     public void download(String catalogName, String dataset, String seriesMember, String distribution, String path) {
+        download(catalogName, dataset, seriesMember, distribution, path, new HashMap<>());
+    }
+
+    /**
+     * Download a single distribution to the local filesystem
+     *
+     * @param catalogName  identifier of the catalog to be queried
+     * @param dataset      a String representing the dataset identifier to download.
+     * @param seriesMember a String representing the series member identifier.
+     * @param distribution a String representing the distribution identifier, this is the file extension.
+     * @param path         the absolute file path where the file should be written.
+     * @param headers       http headers to be provided in the request.  For headers with multiple instances, the value should be a csv list
+     * @throws APICallException if the call to the Fusion API fails
+     * @throws FileDownloadException if there is an issue handling the response from Fusion API
+     * @throws OAuthException if a token could not be retrieved for authentication
+     */
+    public void download(
+            String catalogName,
+            String dataset,
+            String seriesMember,
+            String distribution,
+            String path,
+            Map<String, String> headers) {
 
         String url = String.format(
                 "%scatalogs/%s/datasets/%s/datasetseries/%s/distributions/%s",
@@ -405,7 +428,7 @@ public class Fusion {
             throw new FusionException(String.format("Unable to save to target path %s", path), e);
         }
         String filepath = String.format("%s/%s_%s_%s.%s", path, catalogName, dataset, seriesMember, distribution);
-        this.api.callAPIFileDownload(url, filepath, catalogName, dataset);
+        this.api.callAPIFileDownload(url, filepath, catalogName, dataset, headers);
     }
 
     /**
@@ -420,6 +443,23 @@ public class Fusion {
      * @throws OAuthException if a token could not be retrieved for authentication
      */
     public void download(String catalogName, String dataset, String seriesMember, String distribution) {
+        this.download(catalogName, dataset, seriesMember, distribution, getDefaultPath(), new HashMap<>());
+    }
+
+    /**
+     * Download a single distribution to the local filesystem. By default, this will write to downloads folder.
+     *
+     * @param catalogName  identifier of the catalog to be queried
+     * @param dataset      a String representing the dataset identifier to download.
+     * @param seriesMember a String representing the series member identifier.
+     * @param distribution a String representing the distribution identifier, this is the file extension.
+     * @param headers       http headers to be provided in the request.  For headers with multiple instances, the value should be a csv list
+     * @throws APICallException if the call to the Fusion API fails
+     * @throws FileDownloadException  if there is an issue handling the response from Fusion API
+     * @throws OAuthException if a token could not be retrieved for authentication
+     */
+    public void download(
+            String catalogName, String dataset, String seriesMember, String distribution, Map<String, String> headers) {
         this.download(catalogName, dataset, seriesMember, distribution, getDefaultPath());
     }
 
@@ -456,7 +496,29 @@ public class Fusion {
         String url = String.format(
                 "%scatalogs/%s/datasets/%s/datasetseries/%s/distributions/%s",
                 this.rootURL, catalogName, dataset, seriesMember, distribution);
-        return this.api.callAPIFileDownload(url, catalogName, dataset);
+        return downloadStream(catalogName, dataset, seriesMember, distribution, new HashMap<>());
+    }
+
+    /**
+     * Download a single distribution and return the data as an InputStream
+     * Note that users of this method are required to close the returned InputStream. Failure to do so will
+     * result in resource leaks, including the Http connection used to communicate with Fusion
+     *
+     * @param catalogName  identifier of the catalog to be queried
+     * @param dataset      a String representing the dataset identifier to download.
+     * @param seriesMember a String representing the series member identifier.
+     * @param distribution a String representing the distribution identifier, this is the file extension.
+     * @param headers       http headers to be provided in the request.  For headers with multiple instances, the value should be a csv list
+     * @throws APICallException if the call to the Fusion API fails
+     * @throws FileDownloadException if there is an issue handling the response from Fusion API
+     * @throws OAuthException if a token could not be retrieved for authentication
+     */
+    public InputStream downloadStream(
+            String catalogName, String dataset, String seriesMember, String distribution, Map<String, String> headers) {
+        String url = String.format(
+                "%scatalogs/%s/datasets/%s/datasetseries/%s/distributions/%s",
+                this.rootURL, catalogName, dataset, seriesMember, distribution);
+        return this.api.callAPIFileDownload(url, catalogName, dataset, headers);
     }
 
     /**

--- a/src/main/java/io/github/jpmorganchase/fusion/FusionConfiguration.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/FusionConfiguration.java
@@ -52,13 +52,6 @@ public class FusionConfiguration {
     int uploadPartSize = 8;
 
     /**
-     * Max in flux data to be read at a given time.  Defaults to 500MB.
-     * If a value such as 1gb is required, then client would set this value to 1000;
-     */
-    @Builder.Default
-    long maxInFluxDataSize = 500;
-
-    /**
      * Size of Thread-Pool to be used for uploading chunks of a multipart file
      * Defaults to number of available processors.
      */

--- a/src/main/java/io/github/jpmorganchase/fusion/api/FusionAPIManager.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/api/FusionAPIManager.java
@@ -52,15 +52,16 @@ public class FusionAPIManager implements APIManager {
     }
 
     @Override
-    public void callAPIFileDownload(String apiPath, String fileName, String catalog, String dataset)
+    public void callAPIFileDownload(
+            String apiPath, String fileName, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {
-        downloader.callAPIFileDownload(apiPath, fileName, catalog, dataset);
+        downloader.callAPIFileDownload(apiPath, fileName, catalog, dataset, headers);
     }
 
     @Override
-    public InputStream callAPIFileDownload(String apiPath, String catalog, String dataset)
+    public InputStream callAPIFileDownload(String apiPath, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {
-        return downloader.callAPIFileDownload(apiPath, catalog, dataset);
+        return downloader.callAPIFileDownload(apiPath, catalog, dataset, headers);
     }
 
     @Override

--- a/src/main/java/io/github/jpmorganchase/fusion/api/operations/APIDownloadOperations.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/api/operations/APIDownloadOperations.java
@@ -3,13 +3,15 @@ package io.github.jpmorganchase.fusion.api.operations;
 import io.github.jpmorganchase.fusion.api.exception.APICallException;
 import io.github.jpmorganchase.fusion.api.exception.FileDownloadException;
 import java.io.InputStream;
+import java.util.Map;
 
 public interface APIDownloadOperations {
 
-    default void callAPIFileDownload(String apiPath, String fileName, String catalog, String dataset)
+    default void callAPIFileDownload(
+            String apiPath, String fileName, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {}
 
-    default InputStream callAPIFileDownload(String apiPath, String catalog, String dataset)
+    default InputStream callAPIFileDownload(String apiPath, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {
         return null;
     }

--- a/src/main/java/io/github/jpmorganchase/fusion/api/operations/FusionAPIDownloadOperations.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/api/operations/FusionAPIDownloadOperations.java
@@ -49,12 +49,14 @@ public class FusionAPIDownloadOperations implements APIDownloadOperations {
      * @param filePath the absolute path where the file will be persisted.
      * @param catalog the catalog the distribution to be downloaded is part of
      * @param dataset the dataset the distribution to be downloaded is a member of
+     * @param headers http headers to be provided in the request.  For headers with multiple instances, the value should be a csv list
      * @throws APICallException if the call to the Fusion API fails
      * @throws FileDownloadException if there is an issue handling the response from Fusion API
      * @throws OAuthException if a token could not be retrieved for authentication
      */
     @Override
-    public void callAPIFileDownload(String apiPath, String filePath, String catalog, String dataset)
+    public void callAPIFileDownload(
+            String apiPath, String filePath, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {
 
         DownloadRequest dr = DownloadRequest.builder()
@@ -62,6 +64,7 @@ public class FusionAPIDownloadOperations implements APIDownloadOperations {
                 .filePath(filePath)
                 .catalog(catalog)
                 .dataset(dataset)
+                .headers(headers)
                 .build();
 
         downloadToFile(dr);
@@ -73,12 +76,13 @@ public class FusionAPIDownloadOperations implements APIDownloadOperations {
      * @param apiPath the URL of the API endpoint to call
      * @param catalog the catalog the distribution to be downloaded is part of
      * @param dataset the dataset the distribution to be downloaded is a member of
+     * @param headers http headers to be provided in the request.  For headers with multiple instances, the value should be a csv list
      * @throws APICallException if the call to the Fusion API fails
      * @throws FileDownloadException if there is an issue handling the response from Fusion API
      * @throws OAuthException if a token could not be retrieved for authentication
      */
     @Override
-    public InputStream callAPIFileDownload(String apiPath, String catalog, String dataset)
+    public InputStream callAPIFileDownload(String apiPath, String catalog, String dataset, Map<String, String> headers)
             throws APICallException, FileDownloadException {
 
         DownloadRequest dr = DownloadRequest.builder()
@@ -86,6 +90,7 @@ public class FusionAPIDownloadOperations implements APIDownloadOperations {
                 .catalog(catalog)
                 .dataset(dataset)
                 .isDownloadToStream(true)
+                .headers(headers)
                 .build();
 
         return downloadToStream(dr);

--- a/src/main/java/io/github/jpmorganchase/fusion/api/request/DownloadRequest.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/api/request/DownloadRequest.java
@@ -1,5 +1,6 @@
 package io.github.jpmorganchase.fusion.api.request;
 
+import java.util.Map;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -18,4 +19,5 @@ public class DownloadRequest {
     private String dataset;
     private String filePath;
     private boolean isDownloadToStream;
+    private Map<String, String> headers;
 }

--- a/src/main/java/io/github/jpmorganchase/fusion/api/request/PartFetcher.java
+++ b/src/main/java/io/github/jpmorganchase/fusion/api/request/PartFetcher.java
@@ -11,6 +11,7 @@ import io.github.jpmorganchase.fusion.oauth.provider.FusionTokenProvider;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -70,7 +71,7 @@ public class PartFetcher {
 
     private Map<String, String> getSecurityHeaders(PartRequest pr) {
         DownloadRequest dr = pr.getDownloadRequest();
-        Map<String, String> headers = new HashMap<>();
+        Map<String, String> headers = Optional.ofNullable(dr.getHeaders()).orElse(new HashMap<>());
         headers.put("Authorization", "Bearer " + credentials.getSessionBearerToken());
         headers.put(
                 "Fusion-Authorization",

--- a/src/test/java/io/github/jpmorganchase/fusion/FusionTest.java
+++ b/src/test/java/io/github/jpmorganchase/fusion/FusionTest.java
@@ -187,7 +187,8 @@ public class FusionTest {
                                 config.getRootURL(), "common", "sample_dataset", "20230308", "csv"),
                         String.format("%s/%s_%s_%s.%s", TMP_PATH, "common", "sample_dataset", "20230308", "csv"),
                         "common",
-                        "sample_dataset");
+                        "sample_dataset",
+                        new HashMap<>());
 
         f.download("common", "sample_dataset", "20230308", "csv", TMP_PATH);
     }
@@ -204,7 +205,8 @@ public class FusionTest {
                                 config.getRootURL(), "common", "sample_dataset", "20230308", "csv"),
                         String.format("%s/%s_%s_%s.%s", "downloads", "common", "sample_dataset", "20230308", "csv"),
                         "common",
-                        "sample_dataset");
+                        "sample_dataset",
+                        new HashMap<>());
 
         f.download("common", "sample_dataset", "20230308", "csv");
     }
@@ -218,7 +220,8 @@ public class FusionTest {
                                 "%scatalogs/%s/datasets/%s/datasetseries/%s/distributions/%s",
                                 config.getRootURL(), "common", "sample_dataset", "20230308", "csv"),
                         "common",
-                        "sample_dataset"))
+                        "sample_dataset",
+                        new HashMap<>()))
                 .thenReturn(new ByteArrayInputStream("A,B,C\nD,E,F".getBytes()));
 
         InputStream response = f.downloadStream("common", "sample_dataset", "20230308", "csv");

--- a/src/test/java/io/github/jpmorganchase/fusion/api/operations/FusionAPIDownloadOperationsTest.java
+++ b/src/test/java/io/github/jpmorganchase/fusion/api/operations/FusionAPIDownloadOperationsTest.java
@@ -63,7 +63,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("version-123", 1, "47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=", 5);
         givenCallToPartFetcherForSinglePartReturns("A,B,C\n1,2,3");
 
@@ -83,7 +84,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("version-123", 1, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=", 5);
         givenCallToPartFetcherForSinglePartFails(500);
 
@@ -103,7 +105,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads///common/-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
 
         givenCallToPartFetcherToGetHeadReturns("version-123", 1, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=", 5);
         givenCallToPartFetcherForSinglePartReturns("A,B,C\n1,2,3");
@@ -123,7 +126,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("a1", 5, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=-5", 23);
 
         givenCallToPartFetcherSuccess(
@@ -154,7 +158,8 @@ class FusionAPIDownloadOperationsTest {
                 "commob",
                 "API_TST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToClientToGetHeadFails(500);
 
         // When
@@ -174,7 +179,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("a1", 5, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=-5", 23);
 
         givenCallToPartFetcherSuccess(
@@ -203,7 +209,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("a1", 5, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=-5", 23);
 
         givenCallToPartFetcherSuccess("A,B,C", 1, "a1", "c1", 5, 23, 0, 4, 23);
@@ -229,7 +236,8 @@ class FusionAPIDownloadOperationsTest {
         givenDownloadRequestForStream(
                 "common",
                 "API_TEST",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenCallToPartFetcherToGetHeadReturns("version-123", 1, "U9Wqny3Wh4uvBG7jlJ249WgvG/A+Ue2C+iQ7P8r22G8=", 5);
 
         givenCallToPartFetcherForSinglePartReturns("A,B,C\n1,2,3");
@@ -249,7 +257,8 @@ class FusionAPIDownloadOperationsTest {
         givenDownloadRequestForStream(
                 "common",
                 "API_TEST",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenDownloadBody("A,B,C\n1,2,3");
         givenCallToPartFetcherToGetHeadReturns("version-123", 1, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=", 5);
         givenCallToPartFetcherForSinglePartFails(504);
@@ -269,7 +278,8 @@ class FusionAPIDownloadOperationsTest {
         givenDownloadRequestForStream(
                 "common",
                 "API_TEST",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
 
         givenCallToPartFetcherToGetHeadReturns("a1", 5, "SFiERkoisri4Xv+MPlq3mtarmxbkmHPSaeLAXeNDk6A=-5", 23);
         givenCallToPartFetcherSuccess(
@@ -300,7 +310,8 @@ class FusionAPIDownloadOperationsTest {
                 "common",
                 "API_TEST",
                 "downloads/common-API_TEST-20230319.csv",
-                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv");
+                "http://localhost:8080/test/catalogs/common/datasets/API_TEST/datasetseries/20230319/distributions/csv",
+                Collections.singletonMap("fusion-e2e", "rootId/Id"));
         givenHead("a1", "c", 23L, 5);
 
         givenCallToPartFetcherSuccess(
@@ -321,12 +332,14 @@ class FusionAPIDownloadOperationsTest {
         thenTheFileShouldMatchExpected();
     }
 
-    private void givenDownloadRequestForStream(String catalog, String dataset, String apiPath) {
+    private void givenDownloadRequestForStream(
+            String catalog, String dataset, String apiPath, Map<String, String> headers) {
         downloadRequest = DownloadRequest.builder()
                 .catalog(catalog)
                 .dataset(dataset)
                 .apiPath(apiPath)
                 .isDownloadToStream(true)
+                .headers(headers)
                 .build();
     }
 
@@ -419,13 +432,15 @@ class FusionAPIDownloadOperationsTest {
                 .willThrow(new APICallException(failureStatus, "broken response"));
     }
 
-    private void givenDownloadRequestForFile(String catalog, String dataset, String fileName, String apiPath) {
+    private void givenDownloadRequestForFile(
+            String catalog, String dataset, String fileName, String apiPath, Map<String, String> headers) {
         this.downloadRequest = DownloadRequest.builder()
                 .apiPath(apiPath)
                 .catalog(catalog)
                 .dataset(dataset)
                 .filePath(fileName)
                 .isDownloadToStream(false)
+                .headers(headers)
                 .build();
     }
 
@@ -482,7 +497,8 @@ class FusionAPIDownloadOperationsTest {
                 downloadRequest.getApiPath(),
                 downloadRequest.getFilePath(),
                 downloadRequest.getCatalog(),
-                downloadRequest.getDataset());
+                downloadRequest.getDataset(),
+                downloadRequest.getHeaders());
     }
 
     private void whenFusionApiManagerIsCalledToDownloadFileToPathAndExceptionIsExcepted(
@@ -493,7 +509,8 @@ class FusionAPIDownloadOperationsTest {
                         downloadRequest.getApiPath(),
                         downloadRequest.getFilePath(),
                         downloadRequest.getCatalog(),
-                        downloadRequest.getDataset()));
+                        downloadRequest.getDataset(),
+                        downloadRequest.getHeaders()));
     }
 
     private void thenTheDownloadBodyShouldMatchExpected() throws Exception {
@@ -507,14 +524,20 @@ class FusionAPIDownloadOperationsTest {
 
     private void whenApiIsCalledToDownloadFileAsStream() {
         responseStream = apiDownloader.callAPIFileDownload(
-                downloadRequest.getApiPath(), downloadRequest.getCatalog(), downloadRequest.getDataset());
+                downloadRequest.getApiPath(),
+                downloadRequest.getCatalog(),
+                downloadRequest.getDataset(),
+                downloadRequest.getHeaders());
     }
 
     private void whenApiIsCalledToDownloadFileAsStreamFailsWith(Class<? extends Throwable> expected) {
         throwable = Assertions.assertThrows(
                 expected,
                 () -> apiDownloader.callAPIFileDownload(
-                        downloadRequest.getApiPath(), downloadRequest.getCatalog(), downloadRequest.getDataset()));
+                        downloadRequest.getApiPath(),
+                        downloadRequest.getCatalog(),
+                        downloadRequest.getDataset(),
+                        downloadRequest.getHeaders()));
     }
 
     private void givenCallToPartFetcherForSinglePartReturns(String content) {


### PR DESCRIPTION
This includes the following.

- Custom headers can now be included in the download request.
- Fix for uploads where the provided stream cannot guarantee to fill the given buffer for each read request. 